### PR TITLE
feature/sorting-keypoints-in-python-demo

### DIFF
--- a/Python/demo.py
+++ b/Python/demo.py
@@ -24,8 +24,9 @@ def main():
     cv2.imshow("Detected FAST keypoints", img2)
     cv2.waitKey(0)
 
-    # keypoints should be sorted by strength in descending order before feeding to SSC to work correctly
-    shuffle(keypoints)  # simulating sorting by score with random shuffle
+    # keypoints should be sorted by strength in descending order
+    # before feeding to SSC to work correctly
+    keypoints = sorted(keypoints, key = lambda x:x.response, reverse=True)
 
     selected_keypoints = ssc(
         keypoints, args.num_ret_points, args.tolerance, img.shape[1], img.shape[0]

--- a/Python/demo.py
+++ b/Python/demo.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-from random import shuffle
 
 import cv2  # pylint: disable=import-error
 from ssc import ssc
@@ -26,7 +25,7 @@ def main():
 
     # keypoints should be sorted by strength in descending order
     # before feeding to SSC to work correctly
-    keypoints = sorted(keypoints, key = lambda x:x.response, reverse=True)
+    keypoints = sorted(keypoints, key=lambda x: x.response, reverse=True)
 
     selected_keypoints = ssc(
         keypoints, args.num_ret_points, args.tolerance, img.shape[1], img.shape[0]

--- a/Python/demo.py
+++ b/Python/demo.py
@@ -18,9 +18,9 @@ def main():
     cv2.imshow("Input Image", img)
     cv2.waitKey(0)
 
-    fast = cv2.FastFeatureDetector()
+    fast = cv2.FastFeatureDetector_create()
     keypoints = fast.detect(img, None)
-    img2 = cv2.drawKeypoints(img, keypoints, color=(255, 0, 0))
+    img2 = cv2.drawKeypoints(img, keypoints, outImage=None, color=(255, 0, 0))
     cv2.imshow("Detected FAST keypoints", img2)
     cv2.waitKey(0)
 
@@ -31,7 +31,7 @@ def main():
         keypoints, args.num_ret_points, args.tolerance, img.shape[1], img.shape[0]
     )
 
-    img3 = cv2.drawKeypoints(img, selected_keypoints, color=(255, 0, 0))
+    img3 = cv2.drawKeypoints(img, selected_keypoints, outImage=None, color=(255, 0, 0))
     cv2.imshow("Selected keypoints", img3)
     cv2.waitKey(0)
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ For more details about the algorithm, experiments as well as the importance of h
 
 ## How to run
 1. Clone this repository: ``` git clone https://github.com/BAILOOL/ANMS-Codes.git ```
-2. Choose your language: [C++](https://github.com/BAILOOL/ANMS-Codes/tree/master/C++), [Python](https://github.com/BAILOOL/ANMS-Codes/tree/master/Python), [Matlab](https://github.com/BAILOOL/ANMS-Codes/tree/master/Matlab) [![View ANMS-Codes on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://uk.mathworks.com/matlabcentral/fileexchange/88723-anms-codes), or [Java](https://github.com/BAILOOL/ANMS-Codes/tree/master/Java).
+2. Choose your language:
+    - [C++](https://github.com/BAILOOL/ANMS-Codes/tree/master/C++)
+    - [Python](https://github.com/BAILOOL/ANMS-Codes/tree/master/Python)
+    - [Matlab](https://github.com/BAILOOL/ANMS-Codes/tree/master/Matlab) [![View ANMS-Codes on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://uk.mathworks.com/matlabcentral/fileexchange/88723-anms-codes)
+    - [Java](https://github.com/BAILOOL/ANMS-Codes/tree/master/Java)
 
-3. Make sure the [path to test image](https://github.com/BAILOOL/ANMS-Codes/blob/d907ca805fcf1ea670ac75a9ea9b46446421e573/C++/CmakeProject/source/main.cpp#L8) is set correctly.
+3. Make sure the [path to test image](https://github.com/BAILOOL/ANMS-Codes/blob/d907ca805fcf1ea670ac75a9ea9b46446421e573/C++/CmakeProject/source/main.cpp#L8) is set correctly
 
-4. Run produced executable ```shell ./ANMS_Codes``` for C++ or relevant script for other languages.
+4. Run produced executable `./ANMS_Codes` for C++ or relevant script for other languages
 
 Codes are tested with OpenCV 2.4.8, OpenCV 3.3.1 and Ubuntu 14.04, 16.04.
 


### PR DESCRIPTION
Previously, the keypoints were simply shuffled before feeding to the SSC. It is now sorted in a decreasing order of strength -- which is a proper way.